### PR TITLE
Remove newlines from path

### DIFF
--- a/build-all.sh
+++ b/build-all.sh
@@ -19,4 +19,4 @@ asdf global elixir ${ELIXIR_VERSION}
 mix local.hex --force
 mix local.rebar --force
 
-echo "\nPATH=\$HOME/.asdf/bin:\$HOME/.asdf/shims:\$PATH\n" >> /root/.bashrc
+echo "PATH=\$HOME/.asdf/bin:\$HOME/.asdf/shims:\$PATH" >> /root/.bashrc

--- a/build-all.sh
+++ b/build-all.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 export ERLANG_VERSION="18.2"
-export ELIXIR_VERSION="1.2.5"
+export ELIXIR_VERSION="1.2.6"
 
 apt-get -y update
 apt-get -y install wget git build-essential libncurses-dev libssl-dev openssl unzip


### PR DESCRIPTION
Why do we need this change?
----

When installing the docker image the newlines have been causing
issues, resulting in an incorrect PATH.

What effects does this change have?
----

- Remove newlines from the amended PATH
- Bump elixir version